### PR TITLE
Bumped poison and httpoison versions.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,20 +30,20 @@ defmodule Coverex.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:httpoison, "0.5.0"},
-      {:poison, "~> 1.2.0"},
+      {:httpoison, "0.6.2"},
+      {:poison, "~> 1.3.0"},
       {:earmark, "~> 0.1", only: :dev},
       {:ex_doc, "~> 0.5", only: :dev},
       {:dialyze, "~> 0.1.2", only: :dev}
-    ] 
+    ]
   end
 
   # Hex Package description
   defp description do
     """
-    Coverex is an Elixir Coverage tool used by mix. It provides tables with overviews of 
+    Coverex is an Elixir Coverage tool used by mix. It provides tables with overviews of
     module and function coverage data, includings links to annotated source code files and
-    supports coveralls.io. 
+    supports coveralls.io.
     """
   end
 


### PR DESCRIPTION
In order to run covered with espec needed to bump the versions of poison and httpoison.
From these two apps only httpoison was conflicting with the current elixir version. The case of Poison was my need to run it with maru which requires a more up to date version of poison.
I ran the tests and all seemed to work alright within a app. 