### PR TITLE
Fix warnings under Elixir 1.2

### DIFF
--- a/lib/coverex/templates/overview_text_template.eex
+++ b/lib/coverex/templates/overview_text_template.eex
@@ -1,7 +1,7 @@
 Coverage Report
 ---------------
 Ratio  Covered  Uncovered  Module
-<%= for {e, {c, u}} <- entries, do: 
-  overview_entry_text_template(e, "#{c}", "#{u}", 
-      "#{(1.0 * c/(c + u)*100) |> Float.round 1}") %>
+<%= for {e, {c, u}} <- entries, do:
+  overview_entry_text_template(e, "#{c}", "#{u}",
+      "#{(1.0 * c/(c + u)*100) |> Float.round(1)}") %>
 --------------


### PR DESCRIPTION
Functions must use parenthesis in pipes to avoid potential ambiguity. This also removes trailing whitespace from the edited files. The diff may be easier to see by tacking on `?w=1` to the url.