### PR TITLE
Added totals in output

### DIFF
--- a/lib/coverex/templates/overview_template.eex
+++ b/lib/coverex/templates/overview_template.eex
@@ -20,18 +20,19 @@
           </tr>
         </thead>
         <tbody>
-          <%= for {e, {c, u}} <- entries, do: overview_entry_template(e, c, u, (1.0 * c/(c + u)*100)) %>
+          <%= for {e, {p, c, u}} <- entries, do: overview_entry_template(e, c, u, p) %>
+          <%= {p, c, u} = total; overview_entry_template("Total", c, u, p) %>
         </tbody>
       </table>
     </div>
     <script type="text/javascript">
-    $(document).ready(function() { 
-      // call the tablesorter plugin 
-      $("table").tablesorter({ 
-          // sort on the first column, order asc 
-          sortList: [[0,0]] 
-      }); 
-    }); 
+    $(document).ready(function() {
+      // call the tablesorter plugin
+      $("table").tablesorter({
+          // sort on the first column, order asc
+          sortList: [[0,0]]
+      });
+    });
     </script>
   </body>
 </html>

--- a/lib/coverex/templates/overview_text_template.eex
+++ b/lib/coverex/templates/overview_text_template.eex
@@ -1,7 +1,8 @@
 Coverage Report
 ---------------
 Ratio  Covered  Uncovered  Module
-<%= for {e, {c, u}} <- entries, do:
-  overview_entry_text_template(e, "#{c}", "#{u}",
-      "#{(1.0 * c/(c + u)*100) |> Float.round(1)}") %>
+<%= for {e, {p, c, u}} <- entries, do:
+  overview_entry_text_template(e, "#{c}", "#{u}", "#{p}") %>
 --------------
+Total
+<%= {p,c,u} = total;  overview_entry_text_template("", "#{c}", "#{u}", "#{p}") %>


### PR DESCRIPTION
## MOTIVATION
I want to see the report badge in my gitlab repository.

## Reason
“If you use test coverage in your code, GitLab can capture its output in the build log using a regular expression. In the pipelines settings, search for the "Test coverage parsing" section.”
https://gitlab.com/help/user/project/pipelines/settings#test-coverage-parsing

But coverex does not contain the totals.

## Description
Calculating coverage values.

## Tested
**Environment:**
- Elixir Version: 1.3.0
- Erlang Version: Erlang/OTP 19.0
- Operating System: macOS 10.12.2 (16C67)


## Result
**In my terminal:**
```sh
Generating cover results ...
Coverage Report
---------------
Ratio  Covered  Uncovered  Module
 68.8%      53         24  Elixir.Coverex.Source
  5.8%       6         97  Elixir.Coverex.Task

--------------
Total
 37.3%      59        121
```

 **In my gitlab repository:**

![badge](https://s29.postimg.org/99p1jzzk7/coverage.png)

## Changes
- [x] Added totals in the console output
- [x] Added totals in the html output
