### PR TITLE
Skip non-Elixir modules

### DIFF
--- a/lib/coverex/task.ex
+++ b/lib/coverex/task.ex
@@ -64,6 +64,12 @@ defmodule Coverex.Task do
     |> Enum.reject(fn m ->
       ignore_list |> Enum.member?(m)
     end)
+    |> Enum.filter(fn m ->
+      case Atom.to_string(m) do
+        "Elixir." <> _rest -> true
+        _ -> false
+      end
+    end)
   end
 
   @doc "is post to coveralls requested?"


### PR DESCRIPTION
We have a project which combines Elixir and legacy Erlang code. This patch makes coverex ignore modules that don't start with "Elixir.", so it doesn't try to parse the Erlang source code as Elixir. 