### PR TITLE
allow poison 3.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Coverex.Mixfile do
   defp deps do
     [
       {:hackney, "~> 1.5"},
-      {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"},
+      {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0 or ~> 3.1"},
       {:earmark, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.13", only: :dev},
       {:dialyze, "~> 0.2", only: :dev}


### PR DESCRIPTION
you might want to allow `>= 3.0` or you might not - left this explicit and leaving the other up to you